### PR TITLE
Bug fix: serve gsapi javascript from correct scheme

### DIFF
--- a/src/main/resources/org/sonar/ror/motionchart/app/views/motion_chart/_widget_body.html.erb
+++ b/src/main/resources/org/sonar/ror/motionchart/app/views/motion_chart/_widget_body.html.erb
@@ -4,7 +4,7 @@
 %>
 <% content_for :script do %>
   <script src="<%= ApplicationController.root_context + '/static/motionchart/motionchart-sonar.js' -%>"></script>
-  <script src="http://www.google.com/jsapi"></script>
+  <script src="//www.google.com/jsapi"></script>
   <script>
     google.load('visualization', '1', {'packages': ['motionchart']});
     $j(document).ready(function () {


### PR DESCRIPTION
If sonar is running under https, serving gsapi from http
results in the browser blocking the content.
